### PR TITLE
Update I2C and SPI kernel modules

### DIFF
--- a/WebIOPi-0.7.1/python/webiopi/devices/bus.py
+++ b/WebIOPi-0.7.1/python/webiopi/devices/bus.py
@@ -19,8 +19,8 @@ import subprocess
 from webiopi.utils.logger import debug, info
 
 BUSLIST = {
-    "I2C": {"enabled": False, "gpio": {0:"SDA", 1:"SCL", 2:"SDA", 3:"SCL"}, "modules": ["i2c-bcm2708", "i2c-dev"]},
-    "SPI": {"enabled": False, "gpio": {7:"CE1", 8:"CE0", 9:"MISO", 10:"MOSI", 11:"SCLK"}, "modules": ["spi-bcm2708", "spidev"]},
+    "I2C": {"enabled": False, "gpio": {0:"SDA", 1:"SCL", 2:"SDA", 3:"SCL"}, "modules": ["i2c-bcm2835", "i2c-dev"]},
+    "SPI": {"enabled": False, "gpio": {7:"CE1", 8:"CE0", 9:"MISO", 10:"MOSI", 11:"SCLK"}, "modules": ["spi-bcm2835", "spidev"]},
     "UART": {"enabled": False, "gpio": {14:"TX", 15:"RX"}},
     "ONEWIRE": {"enabled": False, "gpio": {4:"DATA"}, "modules": ["w1-gpio"], "wait": 2}
 }


### PR DESCRIPTION
`spi-bcm2708` has been removed with RPi kernel v4.3: https://github.com/raspberrypi/linux/commit/bdfc988
`i2c-bcm2708` has been deprecated a long time ago: https://forums.raspberrypi.com/viewtopic.php?t=133024

The respective bcm2835 modules are available and compatible with all RPi models.

Fixes: #4