### PR TITLE
fixed AttributeError: 'PiFaceDigital' object has no attribute 'close'

### DIFF
--- a/WebIOPi-0.7.1/python/webiopi/devices/shield/piface.py
+++ b/WebIOPi-0.7.1/python/webiopi/devices/shield/piface.py
@@ -37,6 +37,9 @@ class PiFaceDigital():
         if not channel in range(8):
             raise ValueError("Channel %d invalid" % channel)
     
+    def close(self):
+        None
+    
     @request("GET", "digital/input/%(channel)d")
     @response("%d")
     def digitalRead(self, channel):

--- a/WebIOPi-0.7.1/python/webiopi/devices/spi.py
+++ b/WebIOPi-0.7.1/python/webiopi/devices/spi.py
@@ -54,7 +54,7 @@ SPI_MODE_2      = (SPI_CPOL|0)
 SPI_MODE_3      = (SPI_CPOL|SPI_CPHA)
 
 # does not work
-# SPI_CS_HIGH     = 0x04
+SPI_CS_HIGH     = 0x04
 # SPI_LSB_FIRST   = 0x08
 # SPI_3WIRE       = 0x10
 # SPI_LOOP        = 0x20
@@ -95,7 +95,8 @@ class SPI(Bus):
         if fcntl.ioctl(self.fd, SPI_IOC_RD_MODE, val8):
             raise Exception("Cannot read SPI Mode")
         self.mode = struct.unpack('B', val8)[0]
-        assert(self.mode == mode)
+        self.mode &= ~SPI_CS_HIGH
+        assert(self.mode  == mode)
 
         val8[0] = bits
         if fcntl.ioctl(self.fd, SPI_IOC_WR_BITS_PER_WORD, val8):


### PR DESCRIPTION
Shutting down WebIOPi with pifFace configured throws an AttributeError

# Log

```text
2022-04-21 20:50:14 - WebIOPi - INFO - HTTP Server stopped
2022-04-21 20:50:14 - WebIOPi - DEBUG - Closing device GPIO - GPIO
2022-04-21 20:50:14 - WebIOPi - DEBUG - Closing device pifaceModule - PiFaceDigital(0)
2022-04-21 20:50:14 - WebIOPi - ERROR - 'PiFaceDigital' object has no attribute 'close'
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/WebIOPi-0.7.1-py3.9-linux-armv6l.egg/webiopi/__main__.py", line 75, in <module>
    main(sys.argv)
  File "/usr/local/lib/python3.9/dist-packages/WebIOPi-0.7.1-py3.9-linux-armv6l.egg/webiopi/__main__.py", line 71, in main
    server.stop()
  File "/usr/local/lib/python3.9/dist-packages/WebIOPi-0.7.1-py3.9-linux-armv6l.egg/webiopi/server/__init__.py", line 143, in stop
    manager.closeDevices()
  File "/usr/local/lib/python3.9/dist-packages/WebIOPi-0.7.1-py3.9-linux-armv6l.egg/webiopi/devices/manager.py", line 54, in closeDevices
    device.close()
AttributeError: 'PiFaceDigital' object has no attribute 'close'
2022-04-21 20:50:15 - WebIOPi - INFO - CoAP Server stopped
```


# Possible fix

adding attribute close to piface.py 

```code
    def close(self):
        None
```